### PR TITLE
feat(configuration): :sparkles: provide possibility to configure auto…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,12 @@ jobs:
         run: |
           cat <(echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}") | gpg --batch --import
           gpg --list-secret-keys --keyid-format LONG
+      - name: Define release version
+        run:  |
+          echo "Release of $VERSION triggered ..."
+          mvn -B versions:set -DnewVersion=${{ github.event.release.tag_name }} -DgenerateBackupPoms=false
+        env:
+          VERSION: ${{ github.event.release.tag_name }}
       - name: Publish package
         run: |
           mvn \

--- a/README.md
+++ b/README.md
@@ -7,14 +7,16 @@
     <dependency>
         <groupId>com.monkeydevcommunity</groupId>
         <artifactId>minio-spring-boot-starter</artifactId>
-        <version>1.0.0</version>
+        <version>${minio.version}</version>
     </dependency>
     ```
 * Setup your configuration:
-  * without proxy
     ```yml
-     spring:
+  spring:
       minio:
+        proxy-type: <HTTP|HTTPS> # only if you are using a proxy
+        proxy-host: <YOUR_PROXY_HOST> # only if you are using a proxy
+        proxy-port: <YOUR_PROXY_PORT> # only if you are using a proxy
         url: <YOUR_MINIO_CONFIGURATION>
         access-key: <YOUR_MINIO_ACCESS_KEY>
         secret-key: <YOUR_MINIO_SECRET_KEY>
@@ -24,27 +26,15 @@
         read-timeout: <YOUR_MINIO_READ_TIMEOUT>
         auto-create-bucket: <false|true> # True by default
         buckets:
-          - mybucket1
-          - mybucket2
-      ```
-    * with proxy
-      ```yml
-      spring:
-        minio:
-        enable-proxy: <true|false>
-        proxy-type: <HTTP|HTTPS>
-        proxy-host: <YOUR_PROXY_HOST>
-        proxy-port: <YOUR_PROXY_PORT>
-        url: <YOUR_MINIO_CONFIGURATION>
-        access-key: <YOUR_MINIO_ACCESS_KEY>
-        secret-key: <YOUR_MINIO_SECRET_KEY>
-        default-bucket: <YOUR_MINIO_DEFAULT_BUCKET>
-        connect-timeout: <YOUR_MINIO_CONNECTION_TIMEOUT>
-        write-timeout: <YOUR_MINIO_WRITE_TIMEOUT>
-        read-timeout: <YOUR_MINIO_READ_TIMEOUT>
-        auto-create-bucket: <false|true> # True by default
-        buckets:
-          - mybucket1
-          - mybucket2
-      ```
-
+          - name: mybucket1
+            versioning: <true|false> # False by default
+            objectLocking: <true|false> # required versioning to be enabled. False by default
+            retention: # required versioning and objectLocking to be enabled
+              enabled: <true|false> # False by default
+              mode: <COMPLIANCE|GOVERNANCE> # only if enabled=true
+              duration: 
+                unit: <DAYS|YEARS> # only if enabled=true
+                value: 30 # only if enabled=true
+            policies: 
+              - '{"Statement": [{"Effect": "Allow", "Action": ["s3:GetObject", "s3:GetBucketLocation"], "Resource": ["arn:aws:s3:::*"]}]}'
+    ```

--- a/src/main/java/io/github/xitssky/minio/configuration/MinioAutoConfiguration.java
+++ b/src/main/java/io/github/xitssky/minio/configuration/MinioAutoConfiguration.java
@@ -1,21 +1,25 @@
 package io.github.xitssky.minio.configuration;
 
+import io.github.xitssky.minio.configuration.properties.MinioBucket;
+import io.github.xitssky.minio.configuration.properties.MinioBucketRetentionDuration;
+import io.github.xitssky.minio.configuration.properties.MinioConfigurationProperties;
 import io.github.xitssky.minio.exception.BucketCreationException;
 import io.github.xitssky.minio.exception.InvalidMinioConfigurationException;
+import io.github.xitssky.minio.exception.MinioRequestException;
+import io.github.xitssky.minio.exception.utils.LambdaExceptionUtils;
 import io.github.xitssky.minio.service.MinioService;
-import io.minio.BucketExistsArgs;
-import io.minio.MakeBucketArgs;
-import io.minio.MinioClient;
+import io.minio.*;
+import io.minio.messages.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.OkHttpClient;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.net.InetSocketAddress;
 import java.net.Proxy;
+import java.util.List;
 
 /**
  * Minio auto configuration class
@@ -43,7 +47,8 @@ public class MinioAutoConfiguration {
                 .credentials(this.properties.getAccessKey(), this.properties.getSecretKey());
 
         // Set Client with proxy if the proxy is enabled
-        if (this.properties.isEnableProxy()) {
+        if (this.properties.getProxyHost() != null && !this.properties.getProxyHost().isBlank()
+                && this.properties.getProxyPort() != null && !this.properties.getProxyPort().isBlank()) {
             minioClientBuilder.httpClient(this.getHttpClientWithProxy());
         }
 
@@ -65,35 +70,12 @@ public class MinioAutoConfiguration {
     }
 
     /**
-     * Create a bucket
-     *
-     * @param client: the {@link MinioClient}
-     * @param bucket: the name of the bucket to create
-     * @throws BucketCreationException if something goes wrong during the bucket creation
-     */
-    private void createBucket(MinioClient client, String bucket) throws BucketCreationException {
-        try {
-            // Check that auto creation is enable and bucket doesn't exists
-            if (this.properties.isAutoCreateBucket() && !client.bucketExists(BucketExistsArgs.builder()
-                    .bucket(bucket)
-                    .build())) {
-                // Create the Bucket
-                client.makeBucket(MakeBucketArgs.builder()
-                        .bucket(bucket)
-                        .build());
-            }
-        } catch (Exception ex) {
-            throw new BucketCreationException(bucket, ex);
-        }
-    }
-
-    /**
      * Get an HTTP client with a proxy configured
      *
      * @return an {@link OkHttpClient}
      * @throws InvalidMinioConfigurationException if something is wrong in the configuration
      */
-    private OkHttpClient getHttpClientWithProxy() throws InvalidMinioConfigurationException{
+    private OkHttpClient getHttpClientWithProxy() throws InvalidMinioConfigurationException {
         try {
             final String host = this.properties.getProxyHost();
             final int port = Integer.parseInt(this.properties.getProxyHost());
@@ -107,5 +89,145 @@ public class MinioAutoConfiguration {
         } catch (IllegalArgumentException typeException) {
             throw new InvalidMinioConfigurationException("proxyType", "HTTP | HTTPS");
         }
+    }
+
+    /**
+     * Create a bucket
+     *
+     * @param client:              the {@link MinioClient}
+     * @param bucketConfiguration: the {@link MinioBucket} containing bucket configuration
+     * @throws BucketCreationException if something goes wrong during the bucket creation
+     */
+    private void createBucket(MinioClient client, MinioBucket bucketConfiguration) throws BucketCreationException {
+        try {
+            if (this.properties.isAutoCreateBucket() && !this.bucketExists(bucketConfiguration.getName(), client)) {
+                // Bucket creation
+                client.makeBucket(MakeBucketArgs.builder()
+                        .bucket(bucketConfiguration.getName())
+                        .objectLock(this.getObjectLock(bucketConfiguration))
+                        .build());
+
+                // Versioning configuration
+                final VersioningConfiguration versioningConfiguration = this.getVersioningConfiguration(bucketConfiguration);
+                if (versioningConfiguration != null) {
+                    client.setBucketVersioning(SetBucketVersioningArgs.builder()
+                            .bucket(bucketConfiguration.getName())
+                            .config(versioningConfiguration)
+                            .build());
+                }
+
+                // Object Locking configuration
+                final ObjectLockConfiguration objectLockConfiguration = this.getObjectLockConfiguration(bucketConfiguration);
+                if (objectLockConfiguration != null) {
+                    client.setObjectLockConfiguration(SetObjectLockConfigurationArgs.builder()
+                            .bucket(bucketConfiguration.getName())
+                            .config(objectLockConfiguration)
+                            .build());
+                }
+
+                // Bucket policies configuration
+                final List<String> policiesConfiguration = bucketConfiguration.getPolicies();
+                policiesConfiguration.forEach(LambdaExceptionUtils.handleConsumerException(policyConfiguration -> client.setBucketPolicy(SetBucketPolicyArgs.builder()
+                        .bucket(bucketConfiguration.getName())
+                        .config(policyConfiguration)
+                        .build()), Exception.class));
+            }
+        } catch (Exception ex) {
+            throw new BucketCreationException(bucketConfiguration.getName(), ex);
+        }
+    }
+
+    /**
+     * Check whether a bucket exists or not
+     *
+     * @param bucketName: the name of the bucket to check
+     * @param client:     the {@link MinioClient}
+     * @return the result as {@link Boolean}
+     */
+    private boolean bucketExists(String bucketName, MinioClient client) {
+        try {
+            return client.bucketExists(BucketExistsArgs.builder()
+                    .bucket(bucketName)
+                    .build());
+        } catch (Exception ex) {
+            throw new MinioRequestException("BucketExists", ex);
+        }
+    }
+
+    /**
+     * Check if Versioning is enabled
+     *
+     * @param bucketConfiguration: the {@link MinioBucket} configuration
+     * @return a {@link Boolean}
+     */
+    private VersioningConfiguration getVersioningConfiguration(MinioBucket bucketConfiguration) {
+        return bucketConfiguration.isVersioning() || this.getObjectLock(bucketConfiguration) ?
+                new VersioningConfiguration(VersioningConfiguration.Status.ENABLED, false) :
+                null;
+    }
+
+    /**
+     * Check if Object locking is enabled
+     *
+     * @param bucketConfiguration: the {@link MinioBucket} configuration
+     * @return a {@link Boolean}
+     */
+    private boolean getObjectLock(MinioBucket bucketConfiguration) {
+        return bucketConfiguration.isObjectLocking() || bucketConfiguration.getRetention().isEnabled();
+    }
+
+    /**
+     * Check if Versioning is enabled
+     *
+     * @param bucketConfiguration: the {@link MinioBucket} configuration
+     * @return a {@link Boolean}
+     */
+    private ObjectLockConfiguration getObjectLockConfiguration(MinioBucket bucketConfiguration) {
+        final boolean enabled = bucketConfiguration.getRetention().isEnabled();
+
+        if(enabled) {
+            final RetentionMode mode = this.getRetentionMode(bucketConfiguration.getRetention().getMode());
+            final RetentionDuration duration = this.getMinioRetentionDuration(bucketConfiguration);
+            return mode != null && duration != null ? new ObjectLockConfiguration(mode, duration) : null;
+        }
+        return null;
+    }
+
+    /**
+     * Get the {@link RetentionDuration}
+     *
+     * @param bucketConfiguration: the {@link MinioBucket} configuration
+     * @return the {@link RetentionDuration}
+     */
+    private RetentionDuration getMinioRetentionDuration(MinioBucket bucketConfiguration) {
+        MinioBucketRetentionDuration duration = bucketConfiguration.getRetention().getDuration();
+
+        if(duration != null) {
+            return switch (bucketConfiguration.getRetention().getDuration().getUnit()) {
+                case "YEARS" -> new RetentionDurationYears(duration.getValue());
+                case "DAYS" -> new RetentionDurationDays(duration.getValue());
+                default -> null;
+            };
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the {@link RetentionMode}
+     *
+     * @param mode: the retention mode as {@link String}
+     * @return the {@link RetentionMode}
+     */
+    private RetentionMode getRetentionMode(String mode) {
+        if(mode == null) {
+            return null;
+        }
+
+        return switch (mode) {
+            case "GOVERNANCE" -> RetentionMode.GOVERNANCE;
+            case "COMPLIANCE" -> RetentionMode.COMPLIANCE;
+            default -> null;
+        };
     }
 }

--- a/src/main/java/io/github/xitssky/minio/configuration/properties/MinioBucket.java
+++ b/src/main/java/io/github/xitssky/minio/configuration/properties/MinioBucket.java
@@ -1,0 +1,41 @@
+package io.github.xitssky.minio.configuration.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The Minio Bucket configuration
+ *
+ * @author quentin
+ */
+@Getter
+@Setter
+public class MinioBucket {
+    /**
+     * The name of the bucket
+     */
+    private String name;
+
+    /**
+     * Whether the versioning is enabled or not
+     */
+    private boolean versioning = false;
+
+    /**
+     * Whether the object locking is enabled or not
+     */
+    private boolean objectLocking = false;
+
+    /**
+     * The retention policy to apply to the bucket
+     */
+    private MinioBucketRetention retention;
+
+    /**
+     * The access policies to apply to the bucket
+     */
+    private List<String> policies = new ArrayList<>();
+}

--- a/src/main/java/io/github/xitssky/minio/configuration/properties/MinioBucketRetention.java
+++ b/src/main/java/io/github/xitssky/minio/configuration/properties/MinioBucketRetention.java
@@ -1,0 +1,28 @@
+package io.github.xitssky.minio.configuration.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * The Minio Bucket retention configuration
+ *
+ * @author quentin
+ */
+@Getter
+@Setter
+public class MinioBucketRetention {
+    /**
+     * Whether the retention enabled or bot
+     */
+    private boolean enabled = false;
+
+    /**
+     * The retention mode (COMPLIANCE | GOVERNANCE)
+     */
+    private String mode;
+
+    /**
+     * The retention duration
+     */
+    private MinioBucketRetentionDuration duration;
+}

--- a/src/main/java/io/github/xitssky/minio/configuration/properties/MinioBucketRetentionDuration.java
+++ b/src/main/java/io/github/xitssky/minio/configuration/properties/MinioBucketRetentionDuration.java
@@ -1,0 +1,23 @@
+package io.github.xitssky.minio.configuration.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * The Minio Bucket retention duration configuration
+ *
+ * @author quentin
+ */
+@Getter
+@Setter
+public class MinioBucketRetentionDuration {
+    /**
+     * The unit of the duration (DAYS | YEARS)
+     */
+    private String unit;
+
+    /**
+     * The duration of the retention
+     */
+    private int value;
+}

--- a/src/main/java/io/github/xitssky/minio/configuration/properties/MinioConfigurationProperties.java
+++ b/src/main/java/io/github/xitssky/minio/configuration/properties/MinioConfigurationProperties.java
@@ -1,4 +1,4 @@
-package io.github.xitssky.minio.configuration;
+package io.github.xitssky.minio.configuration.properties;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -34,12 +34,12 @@ public class MinioConfigurationProperties {
     /**
      * The proxy host (to provide only if the proxy is enabled)
      */
-    private String proxyHost;
+    private String proxyHost = null;
 
     /**
      * The proxy port (to provide only if the proxy is enabled)
      */
-    private String proxyPort;
+    private String proxyPort = null;
 
     /**
      * The Minio access key
@@ -74,5 +74,5 @@ public class MinioConfigurationProperties {
     /**
      * All the buckets
      */
-    private List<String> buckets;
+    private List<MinioBucket> buckets;
 }

--- a/src/main/java/io/github/xitssky/minio/exception/utils/ConsumerException.java
+++ b/src/main/java/io/github/xitssky/minio/exception/utils/ConsumerException.java
@@ -1,0 +1,21 @@
+package io.github.xitssky.minio.exception.utils;
+
+import java.util.function.Consumer;
+
+/**
+ * A {@link Consumer} that can throw exception
+ *
+ * @param <T>: the input type of the {@link Consumer}
+ * @param <E>: the exception type that the {@link Consumer} can throw
+ * @author quentin
+ */
+public interface ConsumerException<T, E extends Exception> {
+
+    /**
+     * Apply the function to the {@link T} input
+     *
+     * @param input: the input of the {@link Consumer}
+     * @throws E the exception that the {@link Consumer} can throw
+     */
+    void apply(T input) throws E;
+}

--- a/src/main/java/io/github/xitssky/minio/exception/utils/FunctionException.java
+++ b/src/main/java/io/github/xitssky/minio/exception/utils/FunctionException.java
@@ -1,0 +1,23 @@
+package io.github.xitssky.minio.exception.utils;
+
+import java.util.function.Function;
+
+/**
+ * A {@link Function} that can throw exception
+ *
+ * @param <T>: the input type of the {@link Function}
+ * @param <R>: the output type of the {@link Function}
+ * @param <E> the exception type that the {@link Function} can throw
+ * @author quentin
+ */
+public interface FunctionException<T, R, E extends Exception> {
+
+    /**
+     * Apply the function to the {@link T} input
+     *
+     * @param input: the input of the {@link Function}
+     * @return the {@link R} output of the {@link Function}
+     * @throws E the exception that the {@link Function} can throw
+     */
+    R apply(T input) throws E;
+}

--- a/src/main/java/io/github/xitssky/minio/exception/utils/LambdaExceptionUtils.java
+++ b/src/main/java/io/github/xitssky/minio/exception/utils/LambdaExceptionUtils.java
@@ -1,0 +1,58 @@
+package io.github.xitssky.minio.exception.utils;
+
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * The LambdaException utility class
+ *
+ * @author quentin
+ */
+@Slf4j
+@UtilityClass
+public class LambdaExceptionUtils {
+
+    /**
+     * Wrapper to easily manage exception in {@link Function}
+     *
+     * @param function:       the {@link Function} to run
+     * @param exceptionClass: the Exception {@link Class} that the function can throw
+     * @param <T>:            the input of the {@link Function}
+     * @param <R>:            the output of the {@link Function}
+     * @param <E>:            the exception that the {@link Function} can throw
+     * @return the {@link Function}
+     */
+    public static <T, R, E extends Exception> Function<T, R> handleFunctionException(FunctionException<T, R, E> function, Class<E> exceptionClass) {
+        return (T input) -> {
+            try {
+                return (R) function.apply(input);
+            } catch (Exception functionException) {
+                final E exception = exceptionClass.cast(functionException);
+                throw new RuntimeException(exception.getMessage(), exception.getCause());
+            }
+        };
+    }
+
+    /**
+     * Wrapper to easily manage exception in {@link Consumer}
+     *
+     * @param consumer:       the {@link Consumer} to run
+     * @param exceptionClass: the Exception {@link Class} that the function can throw
+     * @param <T>:            the input of the {@link Consumer}
+     * @param <E>:            the exception that the {@link Consumer} can throw
+     * @return the {@link Consumer}
+     */
+    public static <T, E extends Exception> Consumer<T> handleConsumerException(ConsumerException<T, E> consumer, Class<E> exceptionClass) {
+        return (T input) -> {
+            try {
+                consumer.apply(input);
+            } catch (Exception consumerException) {
+                final E exception = exceptionClass.cast(consumerException);
+                throw new RuntimeException(exception.getMessage(), exception.getCause());
+            }
+        };
+    }
+}

--- a/src/main/java/io/github/xitssky/minio/service/MinioFileService.java
+++ b/src/main/java/io/github/xitssky/minio/service/MinioFileService.java
@@ -13,6 +13,13 @@ import java.util.Map;
  * @author quentin
  */
 public interface MinioFileService {
+    /**
+     * Get the file information
+     * @param filename: the filename
+     * @param bucket:   the name of the bucket on which upload the file
+     * @return information as the {@link StatObjectResponse}
+     * @throws MinioRequestException if information request fail
+     */
     StatObjectResponse getFileInformation(String filename, String bucket) throws MinioRequestException;
 
     /**


### PR DESCRIPTION
Issue linked: #3 

# Type:
- [ ] breaking change
- [X] major enhancement
- [ ] minor enhancement
- [ ] bug

# Previous behavior:

We can only define bucket name in the configuration. There is no way to provide addition configuration to apply to the bucket that has to be auto created.

# New behavior:

we are able to provide configuration (such as retention, policies ...) in the configuration,

# Tests
Are new tests implemented ?
- [ ] yes
- [X] no